### PR TITLE
implement hex to int conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: r
+cache: packages
+
 r:
   - oldrel
   - release
-  - devel
+  - devel  
+  #... osx misses some key dependencies 
+  #missing: magrittr, Rcpp, stringr
+
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: packages
 r:
   - oldrel
   - release
-  - devel  
+  #- devel  
   #... osx misses some key dependencies 
   #missing: magrittr, Rcpp, stringr
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ r:
   - release
   #- devel  
   #... osx misses some key dependencies 
-  #missing: magrittr, Rcpp, stringr
+  #    missing: magrittr, Rcpp, stringr
 
 os:
   - linux

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,6 @@ Version: 0.3.2
 Authors@R: c(
     person("Kota", "Mori", email = "kmori05@gmail.com", role = c("aut", "cre"))
   )
-Maintainer: Kota Mori <kmori05@gmail.com>
 Description:
     Extracts plain text from RTF (Rich Text Format) file.
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     utils
 Suggests:
     testthat
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1
 LinkingTo: Rcpp
 URL: https://github.com/kota7/striprtf
 BugReports: https://github.com/kota7/striprtf/issues

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,10 @@ to_hexstr <- function(x, pad = 4L) {
     .Call('striprtf_to_hexstr', PACKAGE = 'striprtf', x, pad)
 }
 
+hex_to_int <- function(h, sep = 'x') {
+    .Call('striprtf_hex_to_int', PACKAGE = 'striprtf', h, sep)
+}
+
 strip_helper <- function(match_mat, dest_names, special_keys, special_hex, verbose) {
     .Call('striprtf_strip_helper', PACKAGE = 'striprtf', match_mat, dest_names, special_keys, special_hex, verbose)
 }

--- a/R/striprtf.R
+++ b/R/striprtf.R
@@ -128,13 +128,12 @@ strip_rtf <- function(text, verbose = FALSE,
                          verbose = verbose)
   #print(parsed)
 
-  print(parsed$strcode)
-  print(class(parsed$strcode))
-  print(length(parsed$strcode))
-  out <- strsplit(parsed$strcode, "x") %>%
-    lapply(as.hexmode) %>%
-    lapply(intToUtf8)
+  #print(parsed$intcode)
+  # out <- strsplit(parsed$strcode, "x") %>%
+  #   lapply(as.hexmode) %>%
+  #   lapply(intToUtf8)
   #print(out)
+  out <- lapply(parsed$intcode, intToUtf8)
 
   # code page translation
   if (!is.na(cpname)) {

--- a/R/striprtf.R
+++ b/R/striprtf.R
@@ -6,7 +6,7 @@
 #' While it can be informative when parsing a large file,
 #' this option itself makes the process slow.
 #' @param row_start,row_end strings to be added at the beginning and end of table rows
-#' @param cell_end strings to be put at the end of table cells
+#' @param cell_end string to be put at the end of table cells
 #' @param ignore_tables if \code{TRUE}, no special treatment for tables
 #' @param ... Addional arguments passed to \code{\link{readLines}}
 #' @return Character vector of extracted text
@@ -128,6 +128,9 @@ strip_rtf <- function(text, verbose = FALSE,
                          verbose = verbose)
   #print(parsed)
 
+  print(parsed$strcode)
+  print(class(parsed$strcode))
+  print(length(parsed$strcode))
   out <- strsplit(parsed$strcode, "x") %>%
     lapply(as.hexmode) %>%
     lapply(intToUtf8)

--- a/man/read_rtf.Rd
+++ b/man/read_rtf.Rd
@@ -20,7 +20,7 @@ this option itself makes the process slow.}
 
 \item{row_start, row_end}{strings to be added at the beginning and end of table rows}
 
-\item{cell_end}{strings to be put at the end of table cells}
+\item{cell_end}{string to be put at the end of table cells}
 
 \item{ignore_tables}{if \code{TRUE}, no special treatment for tables}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -17,6 +17,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// hex_to_int
+IntegerVector hex_to_int(std::string h, char sep);
+RcppExport SEXP striprtf_hex_to_int(SEXP hSEXP, SEXP sepSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type h(hSEXP);
+    Rcpp::traits::input_parameter< char >::type sep(sepSEXP);
+    rcpp_result_gen = Rcpp::wrap(hex_to_int(h, sep));
+    return rcpp_result_gen;
+END_RCPP
+}
 // strip_helper
 List strip_helper(CharacterMatrix match_mat, CharacterVector dest_names, CharacterVector special_keys, CharacterVector special_hex, bool verbose);
 RcppExport SEXP striprtf_strip_helper(SEXP match_matSEXP, SEXP dest_namesSEXP, SEXP special_keysSEXP, SEXP special_hexSEXP, SEXP verboseSEXP) {

--- a/src/dechex.cpp
+++ b/src/dechex.cpp
@@ -30,7 +30,56 @@ std::string to_hexstr(int x, int pad)
 }
 
 
+IntegerVector hex_to_int(std::string h, char sep)
+{
+  // convert hex string into integer vector
+  //
+  // args:
+  //   h:   hex string in the form e.g., x000AxCA01 ...
+  //   sep: char separating codes in h, if x001Ax0408, ..., then 'x'
+  //
+  // returns:
+  //   integer vector
+
+  h += sep; // make sure the last hex is read
+
+  IntegerVector out;
+  bool started = false;
+  for (int i = 0; i < h.size(); i++)
+  {
+    int start;
+    if (h[i] == sep) {
+      if (!started) {
+        start = i + 1;
+        started = true;
+      } else {
+        int end = i;
+
+        int tmp = 0;
+        for (int k = end-1; k >= start; k--)
+        {
+          char c = h[k];
+          int n;
+          if (c >= '0' && c <= '9')      n = c - '0';
+          else if (c >= 'A' && c <= 'F') n = c - 'A' + 10;
+          else if (c >= 'a' && c <= 'f') n = c - 'a' + 10;
+          else stop("invalid hex");
+
+          tmp += pow(16, end-1-k) * n;
+        }
+        out.push_back(tmp);
+        start = i + 1;
+      }
+    }
+  }
+  return out;
+}
+
 
 /*** R
 striprtf:::to_hexstr(50)
+
+h <- "xffffx0101x00a0"
+striprtf:::hex_to_int(h)
+as.integer(as.hexmode(strsplit(h, 'x')[[1]]))[-1]  # should produce same result
 */

--- a/src/dechex.h
+++ b/src/dechex.h
@@ -12,4 +12,9 @@ using namespace Rcpp;
 // [[Rcpp::export]]
 std::string to_hexstr(int x, int pad = 4);
 
+
+// [[Rcpp::export]]
+IntegerVector hex_to_int(std::string h, char sep = 'x');
+
+
 #endif

--- a/src/strip_helper.cpp
+++ b/src/strip_helper.cpp
@@ -128,6 +128,8 @@ List strip_helper(CharacterMatrix match_mat,
   // returns a list of two vectors of the same length
   //   - strcode : character vector of hex codes, in the form
   //               e.g, x0010x3010...
+  //   - intcode : list of integer vectors of unicodes,
+  //               corresponding to strcode
   //   - toconv  : logocal vector indicating
   //               whether the codes should be converted using the cp tables.
   //
@@ -275,12 +277,17 @@ List strip_helper(CharacterMatrix match_mat,
   // compile output
   CharacterVector str_vec;
   LogicalVector   toconv_vec;
+  List            int_vec_list;
   for (unsigned int i = 0; i < doc.size(); i++)
   {
     str_vec.push_back(doc[i].strcode);
     toconv_vec.push_back(doc[i].toconv);
+
+    int_vec_list.push_back(hex_to_int(doc[i].strcode));
   }
-  List out = List::create(Named("strcode") = str_vec, Named("toconv") = toconv_vec);
+  List out = List::create(Named("strcode") = str_vec,
+                          Named("intcode") = int_vec_list,
+                          Named("toconv") = toconv_vec);
   return out;
 
 }

--- a/src/striprtf_init.c
+++ b/src/striprtf_init.c
@@ -3,22 +3,24 @@
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 
-/* FIXME: 
-   Check these declarations against the C/Fortran source code.
-*/
+/* FIXME:
+ Check these declarations against the C/Fortran source code.
+ */
 
 /* .Call calls */
+extern SEXP striprtf_hex_to_int(SEXP, SEXP);
 extern SEXP striprtf_strip_helper(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP striprtf_to_hexstr(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-    {"striprtf_strip_helper", (DL_FUNC) &striprtf_strip_helper, 5},
-    {"striprtf_to_hexstr",    (DL_FUNC) &striprtf_to_hexstr,    2},
-    {NULL, NULL, 0}
+  {"striprtf_hex_to_int",   (DL_FUNC) &striprtf_hex_to_int,   2},
+  {"striprtf_strip_helper", (DL_FUNC) &striprtf_strip_helper, 5},
+  {"striprtf_to_hexstr",    (DL_FUNC) &striprtf_to_hexstr,    2},
+  {NULL, NULL, 0}
 };
 
 void R_init_striprtf(DllInfo *dll)
 {
-    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
-    R_useDynamicSymbols(dll, FALSE);
+  R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+  R_useDynamicSymbols(dll, FALSE);
 }


### PR DESCRIPTION
`as.hexmode` seems to produce error depending on platforms (maybe max integer size differences).
so wrote hex to int conversion function on my own.

edited travis yaml to test both linux and osx.

